### PR TITLE
Make ScribeCollector reconnect on write errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Space Monkey, Inc.
+Peter Teichman <peter@teichman.org>

--- a/trace/backoff.go
+++ b/trace/backoff.go
@@ -1,0 +1,35 @@
+package trace
+
+import "time"
+
+// backoff implements a backoff policy, randomizing its delays and
+// saturating at its last value.
+type backoff struct {
+	millis []int
+}
+
+// defaultBackoff is a backoff policy ranging up to 5s.
+var defaultBackoff = backoff{
+	[]int{0, 10, 10, 100, 100, 500, 500, 3000, 3000, 5000},
+}
+
+// duration returns the time duration of the n'th wait cycle in its
+// backoff policy. This is backoff.millis[n], randomized to avoid
+// thundering herds.
+func (b backoff) duration(n int) time.Duration {
+	if n >= len(b.millis) {
+		n = len(b.millis) - 1
+	}
+
+	return time.Duration(fudge(b.millis[n])) * time.Millisecond
+}
+
+// fudge returns a random integer uniformly distributed in the range
+// [0.5 * millis .. 1.5 * millis]
+func fudge(millis int) int {
+	if millis == 0 {
+		return 0
+	}
+
+	return millis/2 + Rng.Intn(millis)
+}


### PR DESCRIPTION
Fixes #5

Apologies for the near-complete rewrite of ScribeCollector, but this matched up with some reconnection code we're using elsewhere that's pretty well tested. No API has been modified as part of this patch.

This introduces a buffered channel (`ScribeCollector.logs`) for collecting spans and a background goroutine that maintains a connection to Scribe for sending them out. Next steps could include coalescing multiple spans into a single Scribe Log.

In a failure situation, it will lose the first span it can't write to Scribe, and it will lose spans that arrive after its internal buffer has filled. That seems acceptable to me but you may feel differently.

This has now seen production use on my end, including killing scribe. Let me know if you'd like any changes!
