### PR TITLE
Switch to the new import paths for go.tools

### DIFF
--- a/group_disabled.go
+++ b/group_disabled.go
@@ -17,7 +17,7 @@
 package monitor
 
 import (
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 )
 
 func (g *MonitorGroup) Stats(cb func(name string, val float64)) {}

--- a/group_enabled.go
+++ b/group_enabled.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"github.com/spacemonkeygo/errors"
 	"github.com/spacemonkeygo/monitor/trace"
 )

--- a/trace/ctx.go
+++ b/trace/ctx.go
@@ -17,7 +17,7 @@ package trace
 import (
 	"fmt"
 
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 )
 
 type ctxKey int

--- a/trace/ctx_test.go
+++ b/trace/ctx_test.go
@@ -15,7 +15,7 @@
 package trace_test
 
 import (
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"github.com/spacemonkeygo/monitor/trace"
 )
 

--- a/trace/http.go
+++ b/trace/http.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"sync"
 
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"github.com/spacemonkeygo/errors"
 )
 

--- a/trace/manager.go
+++ b/trace/manager.go
@@ -17,7 +17,7 @@ package trace
 import (
 	"sync"
 
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 	"github.com/spacemonkeygo/monitor/trace/gen-go/zipkin"
 )
 


### PR DESCRIPTION
Clearly this has API implications: the context object is changing type
throughout. Code that uses this library will also need to be updated to the
new import paths.

https://groups.google.com/d/msg/golang-nuts/eD8dh3T9yyA/l5Ail-xfMiAJ
